### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This repository contains Oselvar metrics for the most active repositories in the `swagger-api` GitHub organisation.
 
-You can see the metrics visualized at https://oselvar.com/github/SmartBear/swagger-oselvar-metrics/main
+You can see the metrics visualized at https://www.oselvar.com/github/SmartBear/swagger-oselvar-metrics/main
 
 For more details, see https://github.com/oselvar/oselvar-github-metrics that this repo was forked from.


### PR DESCRIPTION
fixed url
This pull request includes a minor update to the `README.md` file. The change corrects the URL for visualizing metrics by adding "www" to the domain.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L5-R5): Updated the URL for visualizing metrics from `https://oselvar.com/...` to `https://www.oselvar.com/...`